### PR TITLE
Initial Implementation of Resources

### DIFF
--- a/lib/lpt.rb
+++ b/lib/lpt.rb
@@ -12,6 +12,7 @@ require_relative "lpt/lpt_client"
 
 require_relative "lpt/api_operations/create"
 require_relative "lpt/api_operations/retrieve"
+require_relative "lpt/api_operations/update"
 
 require_relative "lpt/resources/api_resource"
 require_relative "lpt/resources/profile"

--- a/lib/lpt.rb
+++ b/lib/lpt.rb
@@ -30,7 +30,12 @@ module Lpt
 
   PREFIX_ENTITY = "LEN"
   PREFIX_MERCHANT = "LMR"
+  PREFIX_MERCHANT_ACCOUNT = "LMA"
   PREFIX_PROFILE = "LID"
+  PREFIX_INSTRUMENT = "LPI"
+  PREFIX_TOKEN = "LTK"
+  PREFIX_PAYMENT = "LPY"
+  PREFIX_VERIFICATION = "LPV"
 
   class << self
     include Lpt::Authentication

--- a/lib/lpt.rb
+++ b/lib/lpt.rb
@@ -15,9 +15,12 @@ require_relative "lpt/api_operations/retrieve"
 require_relative "lpt/api_operations/update"
 
 require_relative "lpt/resources/api_resource"
+require_relative "lpt/resources/instrument"
 require_relative "lpt/resources/profile"
 
 require_relative "lpt/requests/api_request"
+require_relative "lpt/requests/instrument_request"
+require_relative "lpt/requests/instrument_token_request"
 require_relative "lpt/requests/profile_request"
 
 module Lpt

--- a/lib/lpt.rb
+++ b/lib/lpt.rb
@@ -16,11 +16,14 @@ require_relative "lpt/api_operations/update"
 
 require_relative "lpt/resources/api_resource"
 require_relative "lpt/resources/instrument"
+require_relative "lpt/resources/payment"
 require_relative "lpt/resources/profile"
 
 require_relative "lpt/requests/api_request"
+require_relative "lpt/requests/empty_request"
 require_relative "lpt/requests/instrument_request"
 require_relative "lpt/requests/instrument_token_request"
+require_relative "lpt/requests/payment_request"
 require_relative "lpt/requests/profile_request"
 
 module Lpt

--- a/lib/lpt/api_operations/create.rb
+++ b/lib/lpt/api_operations/create.rb
@@ -3,11 +3,24 @@
 module Lpt
   module ApiOperations
     module Create
-      def create(request, _opts = {})
+      def create(request)
         client = Lpt.client
         resource = new
         response = client.post(resource.resources_path, request.to_json)
-        new(response.body)
+        handle_response resource, response
+        resource
+      end
+
+      protected
+
+      def post_request_failed?(response)
+        response.blank? || response.status > 201
+      end
+
+      def handle_response(resource, response)
+        return false if post_request_failed? response
+
+        resource.load_from_response(response.body)
       end
     end
   end

--- a/lib/lpt/api_operations/create.rb
+++ b/lib/lpt/api_operations/create.rb
@@ -3,10 +3,11 @@
 module Lpt
   module ApiOperations
     module Create
-      def create(request)
+      def create(request, path: nil)
         client = Lpt.client
         resource = new
-        response = client.post(resource.resources_path, request.to_json)
+        path ||= resource.resources_path
+        response = client.post(path, request.to_json)
         handle_response resource, response
         resource
       end

--- a/lib/lpt/api_operations/update.rb
+++ b/lib/lpt/api_operations/update.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Lpt
+  module ApiOperations
+    module Update
+      def update(request, _opts = {})
+        client = Lpt.client
+        resource = new
+        response = client.put(resource.resources_path, request.to_json)
+        resource.load_from_response(response.body)
+
+        resource
+      end
+    end
+  end
+end

--- a/lib/lpt/api_operations/update.rb
+++ b/lib/lpt/api_operations/update.rb
@@ -3,7 +3,7 @@
 module Lpt
   module ApiOperations
     module Update
-      def update(id, request, _opts = {})
+      def update(id, request)
         client = Lpt.client
         resource = new(id: id)
         response = client.put(resource.resource_path, request.to_json)

--- a/lib/lpt/api_operations/update.rb
+++ b/lib/lpt/api_operations/update.rb
@@ -3,12 +3,11 @@
 module Lpt
   module ApiOperations
     module Update
-      def update(request, _opts = {})
+      def update(id, request, _opts = {})
         client = Lpt.client
-        resource = new
-        response = client.put(resource.resources_path, request.to_json)
+        resource = new(id: id)
+        response = client.put(resource.resource_path, request.to_json)
         resource.load_from_response(response.body)
-
         resource
       end
     end

--- a/lib/lpt/requests/api_request.rb
+++ b/lib/lpt/requests/api_request.rb
@@ -3,11 +3,17 @@
 module Lpt
   module Requests
     class ApiRequest
+      attr_writer :entity
+
       def initialize(attributes = {})
         attributes.each_pair do |k, v|
           setter = :"#{k}="
           public_send(setter, v)
         end
+      end
+
+      def entity
+        @entity || Lpt.entity
       end
     end
   end

--- a/lib/lpt/requests/api_request.rb
+++ b/lib/lpt/requests/api_request.rb
@@ -3,17 +3,20 @@
 module Lpt
   module Requests
     class ApiRequest
-      attr_writer :entity
+      attr_accessor :entity
 
       def initialize(attributes = {})
         attributes.each_pair do |k, v|
           setter = :"#{k}="
           public_send(setter, v)
         end
+        assign_default_entity
       end
 
-      def entity
-        @entity || Lpt.entity
+      protected
+
+      def assign_default_entity
+        self.entity ||= Lpt.entity
       end
     end
   end

--- a/lib/lpt/requests/empty_request.rb
+++ b/lib/lpt/requests/empty_request.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Lpt
+  module Requests
+    class EmptyRequest
+      def to_json(*)
+        nil
+      end
+    end
+  end
+end

--- a/lib/lpt/requests/instrument_request.rb
+++ b/lib/lpt/requests/instrument_request.rb
@@ -5,8 +5,8 @@ module Lpt
     class InstrumentRequest < ApiRequest
       attr_accessor :profile, :instrument_id, :reference_id, :category, :type,
                     :name, :contact, :address, :account, :expiration,
-                    :security_code, :authentication, :token, :entity,
-                    :external_token, :network_token
+                    :security_code, :authentication, :token, :external_token,
+                    :network_token
     end
   end
 end

--- a/lib/lpt/requests/instrument_request.rb
+++ b/lib/lpt/requests/instrument_request.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Lpt
+  module Requests
+    class InstrumentRequest < ApiRequest
+      attr_accessor :profile,
+                    :instrument_id,
+                    :reference_id,
+                    :category,
+                    :type,
+                    :name,
+                    :contact,
+                    :address,
+                    :account,
+                    :expiration,
+                    :security_code,
+                    :authentication,
+                    :token,
+                    :entity,
+                    :external_token,
+                    :network_token
+    end
+  end
+end

--- a/lib/lpt/requests/instrument_request.rb
+++ b/lib/lpt/requests/instrument_request.rb
@@ -3,22 +3,10 @@
 module Lpt
   module Requests
     class InstrumentRequest < ApiRequest
-      attr_accessor :profile,
-                    :instrument_id,
-                    :reference_id,
-                    :category,
-                    :type,
-                    :name,
-                    :contact,
-                    :address,
-                    :account,
-                    :expiration,
-                    :security_code,
-                    :authentication,
-                    :token,
-                    :entity,
-                    :external_token,
-                    :network_token
+      attr_accessor :profile, :instrument_id, :reference_id, :category, :type,
+                    :name, :contact, :address, :account, :expiration,
+                    :security_code, :authentication, :token, :entity,
+                    :external_token, :network_token
     end
   end
 end

--- a/lib/lpt/requests/instrument_token_request.rb
+++ b/lib/lpt/requests/instrument_token_request.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Lpt
+  module Requests
+    class InstrumentTokenRequest < ApiRequest
+      attr_accessor :profile,
+                    :instrument_id,
+                    :reference_id,
+                    :name,
+                    :contact,
+                    :address,
+                    :expiration,
+                    :token,
+                    :entity
+    end
+  end
+end

--- a/lib/lpt/requests/instrument_token_request.rb
+++ b/lib/lpt/requests/instrument_token_request.rb
@@ -3,15 +3,8 @@
 module Lpt
   module Requests
     class InstrumentTokenRequest < ApiRequest
-      attr_accessor :profile,
-                    :instrument_id,
-                    :reference_id,
-                    :name,
-                    :contact,
-                    :address,
-                    :expiration,
-                    :token,
-                    :entity
+      attr_accessor :profile, :instrument_id, :reference_id, :name, :contact,
+                    :address, :expiration, :token
     end
   end
 end

--- a/lib/lpt/requests/payment_capture_request.rb
+++ b/lib/lpt/requests/payment_capture_request.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Lpt
+  module Requests
+    class PaymentCaptureRequest < ApiRequest
+      attr_accessor :invoice,
+                    :order,
+                    :payment_id,
+                    :reference_id,
+                    :amount,
+                    # :currency,
+                    :session
+    end
+  end
+end

--- a/lib/lpt/requests/payment_capture_request.rb
+++ b/lib/lpt/requests/payment_capture_request.rb
@@ -3,12 +3,7 @@
 module Lpt
   module Requests
     class PaymentCaptureRequest < ApiRequest
-      attr_accessor :invoice,
-                    :order,
-                    :payment_id,
-                    :reference_id,
-                    :amount,
-                    # :currency,
+      attr_accessor :invoice, :order, :payment_id, :reference_id, :amount,
                     :session
     end
   end

--- a/lib/lpt/requests/payment_refund_request.rb
+++ b/lib/lpt/requests/payment_refund_request.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Lpt
+  module Requests
+    class PaymentRefundRequest < ApiRequest
+      attr_accessor :reference_id,
+                    :amount,
+                    :session
+    end
+  end
+end

--- a/lib/lpt/requests/payment_refund_request.rb
+++ b/lib/lpt/requests/payment_refund_request.rb
@@ -3,9 +3,7 @@
 module Lpt
   module Requests
     class PaymentRefundRequest < ApiRequest
-      attr_accessor :reference_id,
-                    :amount,
-                    :session
+      attr_accessor :reference_id, :amount, :session
     end
   end
 end

--- a/lib/lpt/requests/payment_request.rb
+++ b/lib/lpt/requests/payment_request.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Lpt
+  module Requests
+    class PaymentRequest < ApiRequest
+      attr_accessor :merchant,
+                    :merchant_account,
+                    :instrument,
+                    :invoice,
+                    :order,
+                    :payment_id,
+                    :reference_id,
+                    :amount,
+                    :currency,
+                    :session,
+                    :initiation,
+                    :url,
+                    :recurring
+    end
+  end
+end

--- a/lib/lpt/requests/payment_request.rb
+++ b/lib/lpt/requests/payment_request.rb
@@ -3,19 +3,9 @@
 module Lpt
   module Requests
     class PaymentRequest < ApiRequest
-      attr_accessor :merchant,
-                    :merchant_account,
-                    :instrument,
-                    :invoice,
-                    :order,
-                    :payment_id,
-                    :reference_id,
-                    :amount,
-                    :currency,
-                    :session,
-                    :initiation,
-                    :url,
-                    :recurring
+      attr_accessor :merchant, :merchant_account, :instrument, :invoice, :order,
+                    :payment_id, :reference_id, :amount, :currency, :session,
+                    :initiation, :url, :recurring
     end
   end
 end

--- a/lib/lpt/requests/payment_reversal_request.rb
+++ b/lib/lpt/requests/payment_reversal_request.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Lpt
+  module Requests
+    class PaymentReversalRequest < ApiRequest
+      attr_accessor :reference_id,
+                    :amount,
+                    :session
+    end
+  end
+end

--- a/lib/lpt/requests/payment_reversal_request.rb
+++ b/lib/lpt/requests/payment_reversal_request.rb
@@ -3,9 +3,7 @@
 module Lpt
   module Requests
     class PaymentReversalRequest < ApiRequest
-      attr_accessor :reference_id,
-                    :amount,
-                    :session
+      attr_accessor :reference_id, :amount, :session
     end
   end
 end

--- a/lib/lpt/requests/verification_request.rb
+++ b/lib/lpt/requests/verification_request.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Lpt
+  module Requests
+    class VerificationRequest < ApiRequest
+      attr_accessor :metadata,
+                    :verification_id,
+                    :reference_id,
+                    :category,
+                    :type,
+                    :instrument,
+                    :profile,
+                    :subject,
+                    :merchant,
+                    :merchant_account,
+                    :url
+    end
+  end
+end

--- a/lib/lpt/requests/verification_request.rb
+++ b/lib/lpt/requests/verification_request.rb
@@ -3,17 +3,9 @@
 module Lpt
   module Requests
     class VerificationRequest < ApiRequest
-      attr_accessor :metadata,
-                    :verification_id,
-                    :reference_id,
-                    :category,
-                    :type,
-                    :instrument,
-                    :profile,
-                    :subject,
-                    :merchant,
-                    :merchant_account,
-                    :url
+      attr_accessor :metadata, :verification_id, :reference_id, :category,
+                    :type, :instrument, :profile, :subject, :merchant,
+                    :merchant_account, :url
     end
   end
 end

--- a/lib/lpt/resources/api_resource.rb
+++ b/lib/lpt/resources/api_resource.rb
@@ -3,7 +3,7 @@
 module Lpt
   module Resources
     class ApiResource
-      attr_accessor :id, :created, :updated, :status, :created_at, :updated_at
+      attr_accessor :id, :entity, :metadata, :created, :updated, :status, :created_at, :updated_at
 
       def initialize(attributes = {})
         attributes.each_pair do |k, v|
@@ -65,6 +65,23 @@ module Lpt
         MSG
         raise InvalidRequestError, msg
       end
+
+      protected
+        def load_from_response(response)
+          if response === nil
+            return false
+          end
+
+          response.each do |key, value|
+            begin
+              target = :"#{key}="
+              self.send(target, value)
+            rescue
+            end
+          end
+
+          return true
+        end
     end
   end
 end

--- a/lib/lpt/resources/api_resource.rb
+++ b/lib/lpt/resources/api_resource.rb
@@ -3,13 +3,11 @@
 module Lpt
   module Resources
     class ApiResource
-      attr_accessor :id, :entity, :metadata, :created, :updated, :status, :created_at, :updated_at
+      attr_accessor :id, :entity, :metadata, :created, :updated, :status,
+                    :created_at, :updated_at
 
       def initialize(attributes = {})
-        attributes.each_pair do |k, v|
-          setter = :"#{k}="
-          public_send(setter, v)
-        end
+        hydrate_attributes attributes
         assign_object_name
       end
 
@@ -57,7 +55,7 @@ module Lpt
       end
 
       def assert_valid_id_exists!
-        return if id
+        return if id.blank?
 
         msg = <<~MSG
           Could not determine which URL to request: #{self.class} instance has
@@ -66,22 +64,20 @@ module Lpt
         raise InvalidRequestError, msg
       end
 
-      protected
-        def load_from_response(response)
-          if response === nil
-            return false
-          end
+      def load_from_response(response)
+        return if response.blank?
 
-          response.each do |key, value|
-            begin
-              target = :"#{key}="
-              self.send(target, value)
-            rescue
-            end
-          end
+        hydrate_attributes response
+      end
 
-          return true
+      def hydrate_attributes(attributes)
+        attributes.each_pair do |k, v|
+          setter = :"#{k}="
+          public_send(setter, v)
+        rescue NoMethodError
+          # noop
         end
+      end
     end
   end
 end

--- a/lib/lpt/resources/api_resource.rb
+++ b/lib/lpt/resources/api_resource.rb
@@ -33,6 +33,12 @@ module Lpt
         "#{resources_path}/#{CGI.escape(id)}"
       end
 
+      def load_from_response(response)
+        return if response.blank?
+
+        hydrate_attributes response
+      end
+
       protected
 
       def assign_object_name; end
@@ -62,12 +68,6 @@ module Lpt
           an invalid ID: #{id.inspect}
         MSG
         raise ArgumentError, msg
-      end
-
-      def load_from_response(response)
-        return if response.blank?
-
-        hydrate_attributes response
       end
 
       def hydrate_attributes(attributes)

--- a/lib/lpt/resources/api_resource.rb
+++ b/lib/lpt/resources/api_resource.rb
@@ -55,13 +55,13 @@ module Lpt
       end
 
       def assert_valid_id_exists!
-        return if id.blank?
+        return unless id.blank?
 
         msg = <<~MSG
           Could not determine which URL to request: #{self.class} instance has
           an invalid ID: #{id.inspect}
         MSG
-        raise InvalidRequestError, msg
+        raise ArgumentError, msg
       end
 
       def load_from_response(response)

--- a/lib/lpt/resources/instrument.rb
+++ b/lib/lpt/resources/instrument.rb
@@ -10,7 +10,7 @@ module Lpt
       attr_accessor :profile, :metadata, :instrument_id, :reference_id,
                     :category, :type, :account_type, :name, :contact,
                     :address, :identifier, :brand, :network, :issuer_identifier,
-                    :issuer, :expiration, :fingerprint
+                    :issuer, :expiration, :fingerprint, :token
 
       def id_prefix
         Lpt::PREFIX_INSTRUMENT

--- a/lib/lpt/resources/instrument.rb
+++ b/lib/lpt/resources/instrument.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Lpt
+  module Resources
+    class Instrument < ApiResource
+      extend Lpt::ApiOperations::Retrieve
+      extend Lpt::ApiOperations::Create
+      extend Lpt::ApiOperations::Update
+
+      attr_accessor :profile,
+                    :metadata,
+                    :instrument_id,
+                    :reference_id,
+                    :category,
+                    :type,
+                    :account_type,
+                    :name,
+                    :contact,
+                    :address,
+                    :identifier,
+                    :brand,
+                    :network,
+                    :issuer_identifier,
+                    :issuer,
+                    :expiration,
+                    :fingerprint
+
+      def id_prefix
+        Lpt::PREFIX_INSTRUMENT
+      end
+
+      def self.associate_token(token_id, profile_id, _opts = {})
+        request = Lpt::Requests::InstrumentTokenRequest.new
+        request.entity = Lpt.entity
+        request.token = token_id
+        request.profile = profile_id
+
+        client = Lpt.client
+        response = client.post(self.resources_path, request.to_json)
+        if response.status > 201
+          return false
+        end
+
+        new(response.body)
+      end
+
+      protected
+
+      def assign_object_name
+        @object_name = "instrument"
+      end
+    end
+  end
+end

--- a/lib/lpt/resources/instrument.rb
+++ b/lib/lpt/resources/instrument.rb
@@ -7,41 +7,13 @@ module Lpt
       extend Lpt::ApiOperations::Create
       extend Lpt::ApiOperations::Update
 
-      attr_accessor :profile,
-                    :metadata,
-                    :instrument_id,
-                    :reference_id,
-                    :category,
-                    :type,
-                    :account_type,
-                    :name,
-                    :contact,
-                    :address,
-                    :identifier,
-                    :brand,
-                    :network,
-                    :issuer_identifier,
-                    :issuer,
-                    :expiration,
-                    :fingerprint
+      attr_accessor :profile, :metadata, :instrument_id, :reference_id,
+                    :category, :type, :account_type, :name, :contact,
+                    :address, :identifier, :brand, :network, :issuer_identifier,
+                    :issuer, :expiration, :fingerprint
 
       def id_prefix
         Lpt::PREFIX_INSTRUMENT
-      end
-
-      def self.associate_token(token_id, profile_id, _opts = {})
-        request = Lpt::Requests::InstrumentTokenRequest.new
-        request.entity = Lpt.entity
-        request.token = token_id
-        request.profile = profile_id
-
-        client = Lpt.client
-        response = client.post(self.resources_path, request.to_json)
-        if response.status > 201
-          return false
-        end
-
-        new(response.body)
       end
 
       protected

--- a/lib/lpt/resources/payment.rb
+++ b/lib/lpt/resources/payment.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+module Lpt
+  module Resources
+    class Payment < ApiResource
+      extend Lpt::ApiOperations::Retrieve
+      extend Lpt::ApiOperations::Create
+      extend Lpt::ApiOperations::Update
+
+      attr_accessor :payment_id,
+                    :reference_id,
+                    :instrument,
+                    :instrument_identifier,
+                    :initiation,
+                    :merchant,
+                    :merchant_account,
+                    :workflow,
+                    :amount,
+                    :currency,
+                    :entity,
+                    :order,
+                    :invoice,
+                    :session,
+                    :profile,
+                    :authorization,
+                    :presentment,
+                    :reversal,
+                    :refunds,
+                    :amount_refundable,
+                    :result,
+                    :url
+
+      def id_prefix
+        Lpt::PREFIX_PAYMENT
+      end
+
+      class << self
+        def capture(id, request = nil, _opts = {})
+          resource = new(id: id)
+          unless resource.capture(request, _opts)
+            return nil
+          end
+
+          resource
+        end
+
+        def reverse(id, request = nil, _opts = {})
+          resource = new(id: id)
+          unless resource.reverse(request, _opts)
+            return nil
+          end
+
+          resource
+        end
+
+        def void(id, request = nil, _opts = {})
+          resource = new(id: id)
+          unless resource.void(request, _opts)
+            return nil
+          end
+
+          resource
+        end
+
+        def refund(id, request = nil, _opts = {})
+          resource = new(id: id)
+          unless resource.refund(request, _opts)
+            return nil
+          end
+
+          resource
+        end
+      end
+
+      def capture(request = nil, _opts = {})
+        client = Lpt.client
+        path = "#{resource_path}/capture"
+        request_str = request ? request.to_json : nil
+        response = client.post(path, request_str)
+        if response === nil or response.status > 201
+          return false
+        end
+
+        return load_from_response(response.body)
+      end
+
+      def reverse(request = nil, _opts = {})
+        client = Lpt.client
+        path = "#{resource_path}/reverse"
+        request_str = request ? request.to_json : nil
+        response = client.post(path, request_str)
+        if response === nil or response.status > 201
+          return false
+        end
+
+        return load_from_response(response.body)
+      end
+
+      def void(request = nil, _opts = {})
+        client = Lpt.client
+        path = "#{resource_path}/void"
+        request_str = request ? request.to_json : nil
+        response = client.post(path, request_str)
+        if response === nil or response.status > 201
+          return false
+        end
+
+        return load_from_response(response.body)
+      end
+
+      def refund(request = nil, _opts = {})
+        client = Lpt.client
+        path = "#{resource_path}/refund"
+        request_str = request ? request.to_json : nil
+        response = client.post(path, request_str)
+        if response === nil or response.status > 201
+          return false
+        end
+
+        return load_from_response(response.body)
+      end
+
+      protected
+
+      def assign_object_name
+        @object_name = "payment"
+      end
+    end
+  end
+end

--- a/lib/lpt/resources/payment.rb
+++ b/lib/lpt/resources/payment.rb
@@ -7,117 +7,34 @@ module Lpt
       extend Lpt::ApiOperations::Create
       extend Lpt::ApiOperations::Update
 
-      attr_accessor :payment_id,
-                    :reference_id,
-                    :instrument,
-                    :instrument_identifier,
-                    :initiation,
-                    :merchant,
-                    :merchant_account,
-                    :workflow,
-                    :amount,
-                    :currency,
-                    :entity,
-                    :order,
-                    :invoice,
-                    :session,
-                    :profile,
-                    :authorization,
-                    :presentment,
-                    :reversal,
-                    :refunds,
-                    :amount_refundable,
-                    :result,
-                    :url
+      attr_accessor :payment_id, :reference_id, :instrument,
+                    :instrument_identifier, :initiation, :merchant,
+                    :merchant_account, :workflow, :amount, :currency, :order,
+                    :invoice, :session, :profile, :authorization, :presentment,
+                    :reversal, :refunds, :amount_refundable, :result, :url
 
       def id_prefix
         Lpt::PREFIX_PAYMENT
       end
 
-      class << self
-        def capture(id, request = nil, _opts = {})
-          resource = new(id: id)
-          unless resource.capture(request, _opts)
-            return nil
-          end
-
-          resource
-        end
-
-        def reverse(id, request = nil, _opts = {})
-          resource = new(id: id)
-          unless resource.reverse(request, _opts)
-            return nil
-          end
-
-          resource
-        end
-
-        def void(id, request = nil, _opts = {})
-          resource = new(id: id)
-          unless resource.void(request, _opts)
-            return nil
-          end
-
-          resource
-        end
-
-        def refund(id, request = nil, _opts = {})
-          resource = new(id: id)
-          unless resource.refund(request, _opts)
-            return nil
-          end
-
-          resource
-        end
-      end
-
-      def capture(request = nil, _opts = {})
-        client = Lpt.client
+      def capture(request = Lpt::Requests::EmptyRequest.new)
         path = "#{resource_path}/capture"
-        request_str = request ? request.to_json : nil
-        response = client.post(path, request_str)
-        if response === nil or response.status > 201
-          return false
-        end
-
-        return load_from_response(response.body)
+        Lpt::Resources::Payment.create(request, path: path)
       end
 
-      def reverse(request = nil, _opts = {})
-        client = Lpt.client
-        path = "#{resource_path}/reverse"
-        request_str = request ? request.to_json : nil
-        response = client.post(path, request_str)
-        if response === nil or response.status > 201
-          return false
-        end
-
-        return load_from_response(response.body)
-      end
-
-      def void(request = nil, _opts = {})
-        client = Lpt.client
-        path = "#{resource_path}/void"
-        request_str = request ? request.to_json : nil
-        response = client.post(path, request_str)
-        if response === nil or response.status > 201
-          return false
-        end
-
-        return load_from_response(response.body)
-      end
-
-      def refund(request = nil, _opts = {})
-        client = Lpt.client
+      def refund(request = Lpt::Requests::EmptyRequest.new)
         path = "#{resource_path}/refund"
-        request_str = request ? request.to_json : nil
-        response = client.post(path, request_str)
-        if response === nil or response.status > 201
-          return false
-        end
+        Lpt::Resources::Payment.create(request, path: path)
+      end
 
-        return load_from_response(response.body)
+      def reverse(request = Lpt::Requests::EmptyRequest.new)
+        path = "#{resource_path}/reverse"
+        Lpt::Resources::Payment.create(request, path: path)
+      end
+
+      def void(request = Lpt::Requests::EmptyRequest.new)
+        path = "#{resource_path}/void"
+        Lpt::Resources::Payment.create(request, path: path)
       end
 
       protected

--- a/lib/lpt/resources/profile.rb
+++ b/lib/lpt/resources/profile.rb
@@ -5,8 +5,9 @@ module Lpt
     class Profile < ApiResource
       extend Lpt::ApiOperations::Retrieve
       extend Lpt::ApiOperations::Create
+      extend Lpt::ApiOperations::Update
 
-      attr_accessor :entity, :metadata, :profile_id, :reference_id, :name,
+      attr_accessor :profile_id, :reference_id, :name,
                     :contact, :address
 
       def id_prefix

--- a/lib/lpt/resources/profile.rb
+++ b/lib/lpt/resources/profile.rb
@@ -7,17 +7,37 @@ module Lpt
       extend Lpt::ApiOperations::Create
       extend Lpt::ApiOperations::Update
 
-      attr_accessor :profile_id, :reference_id, :name,
-                    :contact, :address
+      attr_accessor :profile_id, :reference_id, :name, :contact, :address
 
       def id_prefix
         Lpt::PREFIX_PROFILE
+      end
+
+      def associate_instrument(instrument_token_request)
+        assert_valid_id_exists!
+        assert_token_exists! instrument_token_request
+        instrument_token_request.profile = id
+        Lpt::Resources::Instrument.create(instrument_token_request)
+      rescue ArgumentError
+        false
       end
 
       protected
 
       def assign_object_name
         @object_name = "profile"
+      end
+
+      def assert_valid_id_exists!
+        return if id.present?
+
+        raise ArgumentError, "A profile ID is required"
+      end
+
+      def assert_token_exists!(request)
+        return if request.token.present?
+
+        raise ArgumentError, "An instrument token is required"
       end
     end
   end

--- a/lib/lpt/resources/verification.rb
+++ b/lib/lpt/resources/verification.rb
@@ -7,18 +7,9 @@ module Lpt
       extend Lpt::ApiOperations::Create
       extend Lpt::ApiOperations::Update
 
-      attr_accessor :verification_id,
-                    :reference_id,
-                    :subject,
-                    :profile,
-                    :instrument,
-                    :merchant,
-                    :merchant_account,
-                    :category,
-                    :type,
-                    :url,
-                    :result,
-                    :verified
+      attr_accessor :verification_id, :reference_id, :subject, :profile,
+                    :instrument, :merchant, :merchant_account, :category, :type,
+                    :url, :result, :verified
 
       def id_prefix
         Lpt::PREFIX_VERIFICATION

--- a/lib/lpt/resources/verification.rb
+++ b/lib/lpt/resources/verification.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Lpt
+  module Resources
+    class Verification < ApiResource
+      extend Lpt::ApiOperations::Retrieve
+      extend Lpt::ApiOperations::Create
+      extend Lpt::ApiOperations::Update
+
+      attr_accessor :verification_id,
+                    :reference_id,
+                    :subject,
+                    :profile,
+                    :instrument,
+                    :merchant,
+                    :merchant_account,
+                    :category,
+                    :type,
+                    :url,
+                    :result,
+                    :verified
+
+      def id_prefix
+        Lpt::PREFIX_VERIFICATION
+      end
+
+      protected
+
+      def assign_object_name
+        @object_name = "verification"
+      end
+    end
+  end
+end

--- a/spec/lpt/requests/empty_request_spec.rb
+++ b/spec/lpt/requests/empty_request_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Lpt::Requests::EmptyRequest do
+  describe "#to_json" do
+    it "returns nothing" do
+      request = Lpt::Requests::EmptyRequest.new
+
+      result = request.to_json
+
+      expect(result).to be_blank
+    end
+  end
+end

--- a/spec/lpt/resources/api_resource_spec.rb
+++ b/spec/lpt/resources/api_resource_spec.rb
@@ -4,9 +4,10 @@ require "spec_helper"
 
 RSpec.describe Lpt::Resources::ApiResource do
   describe "#initialize" do
-    it "set the attribute values" do
-      pending "implement"
-      raise
+    it "sets the attribute values" do
+      result = Lpt::Resources::ApiResource.new(id: "id123")
+
+      expect(result.id).to eq("id123")
     end
 
     context "when passed an attribute with no setter method" do

--- a/spec/lpt/resources/api_resource_spec.rb
+++ b/spec/lpt/resources/api_resource_spec.rb
@@ -48,4 +48,26 @@ RSpec.describe Lpt::Resources::ApiResource do
       }.to raise_error(NotImplementedError)
     end
   end
+
+  describe "#load_from_response" do
+    it "sets the attributes" do
+      resource = Lpt::Resources::ApiResource.new
+      response = { id: "LID" }
+
+      resource.load_from_response(response)
+
+      expect(resource.id).to eq("LID")
+    end
+
+    context "when the response is empty" do
+      it "does not set any attributes" do
+        resource = Lpt::Resources::ApiResource.new
+        response = {}
+
+        resource.load_from_response(response)
+
+        expect(resource.id).to be_blank
+      end
+    end
+  end
 end

--- a/spec/lpt/resources/api_resource_spec.rb
+++ b/spec/lpt/resources/api_resource_spec.rb
@@ -3,6 +3,21 @@
 require "spec_helper"
 
 RSpec.describe Lpt::Resources::ApiResource do
+  describe "#initialize" do
+    it "set the attribute values" do
+      pending "implement"
+      raise
+    end
+
+    context "when passed an attribute with no setter method" do
+      it "does not raise an error" do
+        expect {
+          Lpt::Resources::ApiResource.new(fake_attribute: true)
+        }.not_to raise_error
+      end
+    end
+  end
+
   describe "#base_path" do
     it "returns the API version" do
       allow(Lpt).to receive(:api_version).and_return("vvv")

--- a/spec/lpt/resources/instrument_spec.rb
+++ b/spec/lpt/resources/instrument_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Lpt::Resources::Instrument do
+  describe "#initialize" do
+    it "assigns the object name" do
+      result = Lpt::Resources::Instrument.new
+
+      expect(result.object_name).to be_present
+    end
+  end
+
+  describe ".retrieve" do
+    before { configure_client }
+
+    it "returns the existing instrument" do
+      instrument_id = "#{Lpt::PREFIX_INSTRUMENT}123123123"
+      stub_instrument_retrieve id: instrument_id
+
+      result = Lpt::Resources::Instrument.retrieve(instrument_id)
+
+      expect(result.id).to eq(instrument_id)
+    end
+  end
+
+  describe ".create" do
+    before { configure_client }
+
+    it "returns the created instrument" do
+      instrument_request = Lpt::Requests::InstrumentRequest.new
+      stub_instrument_create
+
+      result = Lpt::Resources::Instrument.create(instrument_request)
+
+      expect(result.id).to be_present
+    end
+  end
+end

--- a/spec/lpt/resources/payment_spec.rb
+++ b/spec/lpt/resources/payment_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Lpt::Resources::Payment do
+  describe "#initialize" do
+    it "assigns the object name" do
+      result = Lpt::Resources::Payment.new
+
+      expect(result.object_name).to be_present
+    end
+  end
+
+  describe "#capture" do
+    before { configure_client }
+
+    it "uses the path for capturing a payment" do
+      resource = Lpt::Resources::Payment.new(id: Lpt::PREFIX_PAYMENT)
+      capture_path = "/v2/payments/#{Lpt::PREFIX_PAYMENT}/capture"
+      client = Lpt.client
+      allow(client).to receive(:post).and_call_original
+      stub_payment_capture id: Lpt::PREFIX_PAYMENT
+      stub_lpt_client client
+
+      resource.capture
+
+      expect(client).to have_received(:post).once.with(capture_path, anything)
+    end
+
+    it "returns the payment" do
+      resource = Lpt::Resources::Payment.new(id: Lpt::PREFIX_PAYMENT)
+      stub_payment_capture id: Lpt::PREFIX_PAYMENT
+
+      result = resource.capture
+
+      expect(result.reference_id).to be_present
+    end
+  end
+
+  describe "#refund" do
+    before { configure_client }
+
+    it "uses the path for refunding a payment" do
+      resource = Lpt::Resources::Payment.new(id: Lpt::PREFIX_PAYMENT)
+      refund_path = "/v2/payments/#{Lpt::PREFIX_PAYMENT}/refund"
+      client = Lpt.client
+      allow(client).to receive(:post).and_call_original
+      stub_payment_refund id: Lpt::PREFIX_PAYMENT
+      stub_lpt_client client
+
+      resource.refund
+
+      expect(client).to have_received(:post).once.with(refund_path, anything)
+    end
+
+    it "returns the payment" do
+      resource = Lpt::Resources::Payment.new(id: Lpt::PREFIX_PAYMENT)
+      stub_payment_refund id: Lpt::PREFIX_PAYMENT
+
+      result = resource.refund
+
+      expect(result.reference_id).to be_present
+    end
+  end
+
+  describe "#reverse" do
+    before { configure_client }
+
+    it "uses the path for reversing a payment" do
+      resource = Lpt::Resources::Payment.new(id: Lpt::PREFIX_PAYMENT)
+      reverse_path = "/v2/payments/#{Lpt::PREFIX_PAYMENT}/reverse"
+      client = Lpt.client
+      allow(client).to receive(:post).and_call_original
+      stub_payment_reverse id: Lpt::PREFIX_PAYMENT
+      stub_lpt_client client
+
+      resource.reverse
+
+      expect(client).to have_received(:post).once.with(reverse_path, anything)
+    end
+
+    it "returns the payment" do
+      resource = Lpt::Resources::Payment.new(id: Lpt::PREFIX_PAYMENT)
+      stub_payment_reverse id: Lpt::PREFIX_PAYMENT
+
+      result = resource.reverse
+
+      expect(result.reference_id).to be_present
+    end
+  end
+
+  describe "#void" do
+    before { configure_client }
+
+    it "uses the path for voiding a payment" do
+      resource = Lpt::Resources::Payment.new(id: Lpt::PREFIX_PAYMENT)
+      void_path = "/v2/payments/#{Lpt::PREFIX_PAYMENT}/void"
+      client = Lpt.client
+      allow(client).to receive(:post).and_call_original
+      stub_payment_void id: Lpt::PREFIX_PAYMENT
+      stub_lpt_client client
+
+      resource.void
+
+      expect(client).to have_received(:post).once.with(void_path, anything)
+    end
+
+    it "returns the payment" do
+      resource = Lpt::Resources::Payment.new(id: Lpt::PREFIX_PAYMENT)
+      stub_payment_void id: Lpt::PREFIX_PAYMENT
+
+      result = resource.void
+
+      expect(result.reference_id).to be_present
+    end
+  end
+
+  describe ".retrieve" do
+    before { configure_client }
+
+    it "returns the existing payment" do
+      payment_id = "#{Lpt::PREFIX_PAYMENT}123123123"
+      stub_payment_retrieve id: payment_id
+
+      result = Lpt::Resources::Payment.retrieve(payment_id)
+
+      expect(result.id).to eq(payment_id)
+    end
+  end
+
+  describe ".create" do
+    before { configure_client }
+
+    it "returns the created payment" do
+      payment_request = Lpt::Requests::PaymentRequest.new
+      stub_payment_create
+
+      result = Lpt::Resources::Payment.create(payment_request)
+
+      expect(result.id).to be_present
+    end
+  end
+end

--- a/spec/lpt/resources/profile_spec.rb
+++ b/spec/lpt/resources/profile_spec.rb
@@ -11,11 +11,74 @@ RSpec.describe Lpt::Resources::Profile do
     end
   end
 
+  describe "#create_instrument" do
+    before { configure_client }
+
+    it "returns a truthy value" do
+      profile_id = "LID123123123123"
+      profile = Lpt::Resources::Profile.new(id: profile_id)
+      request = Lpt::Requests::InstrumentTokenRequest.new(token: "TKN")
+      stub_instrument_create
+
+      result = profile.associate_instrument(request)
+
+      expect(result).to be_truthy
+    end
+
+    it "assigns the profile to the request" do
+      profile_id = "LID123123123123"
+      profile = Lpt::Resources::Profile.new(id: profile_id)
+      request = Lpt::Requests::InstrumentTokenRequest.new(token: "TKN")
+      allow(request).to receive(:profile=).and_call_original
+      stub_instrument_create
+
+      profile.associate_instrument(request)
+
+      expect(request).to have_received(:profile=).once.with(profile_id)
+    end
+
+    it "sends a create request" do
+      profile_id = "LID123123123123"
+      profile = Lpt::Resources::Profile.new(id: profile_id)
+      request = Lpt::Requests::InstrumentTokenRequest.new(token: "TKN")
+      stub_instrument_create
+
+      result = profile.associate_instrument(request)
+
+      expect(result.id).to be_present
+    end
+
+    context "when the profile does not have an ID" do
+      it "returns a falsy value" do
+        profile = Lpt::Resources::Profile.new(id: nil)
+        request = Lpt::Requests::InstrumentTokenRequest.new(token: "TKN")
+        stub_instrument_create
+
+        result = profile.associate_instrument(request)
+
+        expect(result).to be_falsy
+      end
+    end
+
+    context "when the request does not have a token" do
+      it "returns a falsy value" do
+        profile = Lpt::Resources::Profile.new(id: "LID123123123")
+        request = Lpt::Requests::InstrumentTokenRequest.new
+        request.token = nil
+        stub_instrument_create
+
+        result = profile.associate_instrument(request)
+
+        expect(result).to be_falsy
+      end
+    end
+  end
+
   describe ".retrieve" do
     before { configure_client }
 
     it "returns the existing profile" do
-      profile_id = "LID123123123"
+      profile_id = "#{Lpt::PREFIX_PROFILE}123123123"
       stub_profile_retrieve id: profile_id
 
       result = Lpt::Resources::Profile.retrieve(profile_id)
@@ -29,7 +92,7 @@ RSpec.describe Lpt::Resources::Profile do
 
     it "returns the created profile" do
       profile_request = Lpt::Requests::ProfileRequest.new
-      stub_profile_create request: profile_request
+      stub_profile_create
 
       result = Lpt::Resources::Profile.create(profile_request)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,5 +19,6 @@ RSpec.configure do |config|
 
   config.include ClientHelper
   config.include InstrumentHelper
+  config.include PaymentHelper
   config.include ProfileHelper
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,5 +18,6 @@ RSpec.configure do |config|
   end
 
   config.include ClientHelper
+  config.include InstrumentHelper
   config.include ProfileHelper
 end

--- a/spec/support/helpers/client_helper.rb
+++ b/spec/support/helpers/client_helper.rb
@@ -10,6 +10,10 @@ module ClientHelper
     Lpt.environment = environment
   end
 
+  def stub_lpt_client(client)
+    allow(Lpt).to receive(:client).and_return(client)
+  end
+
   def stub_get_request(url:, status:, response_body:)
     headers = { "content-type": "application/json; charset=UTF-8" }
     stub_request(:get, url).
@@ -17,11 +21,9 @@ module ClientHelper
   end
 
   def stub_post_request(url:, status:, response_body:)
-    request_headers = { "Content-Type": "application/json" }
     response_headers = { "content-type": "application/json; charset=UTF-8" }
 
     stub_request(:post, url).
-      with(headers: request_headers).
       to_return(status: status, body: response_body, headers: response_headers)
   end
 end

--- a/spec/support/helpers/client_helper.rb
+++ b/spec/support/helpers/client_helper.rb
@@ -16,12 +16,12 @@ module ClientHelper
       to_return(status: status, body: response_body, headers: headers)
   end
 
-  def stub_post_request(url:, request_body:, status:, response_body:)
+  def stub_post_request(url:, status:, response_body:)
     request_headers = { "Content-Type": "application/json" }
     response_headers = { "content-type": "application/json; charset=UTF-8" }
 
     stub_request(:post, url).
-      with(body: request_body, headers: request_headers).
+      with(headers: request_headers).
       to_return(status: status, body: response_body, headers: response_headers)
   end
 end

--- a/spec/support/helpers/instrument_helper.rb
+++ b/spec/support/helpers/instrument_helper.rb
@@ -9,7 +9,7 @@ module InstrumentHelper
 
   def stub_instrument_create
     stub_post_request url: "https://api.test.lpt.local/v2/instruments",
-                      status: 200,
+                      status: 201,
                       response_body: instrument_response
   end
 

--- a/spec/support/helpers/instrument_helper.rb
+++ b/spec/support/helpers/instrument_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module InstrumentHelper
+  def stub_instrument_retrieve(id: Lpt::PREFIX_INSTRUMENT)
+    stub_get_request url: "https://api.test.lpt.local/v2/instruments/#{id}",
+                     response_body: instrument_response(id: id),
+                     status: 200
+  end
+
+  def stub_instrument_create
+    stub_post_request url: "https://api.test.lpt.local/v2/instruments",
+                      status: 200,
+                      response_body: instrument_response
+  end
+
+  def instrument_response(id: Lpt::PREFIX_INSTRUMENT)
+    <<~JSON
+      {
+        "id": "#{id}"
+      }
+    JSON
+  end
+end

--- a/spec/support/helpers/payment_helper.rb
+++ b/spec/support/helpers/payment_helper.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module PaymentHelper
+  def stub_payment_capture(id: Lpt::PREFIX_PAYMENT)
+    url = "https://api.test.lpt.local/v2/payments/#{id}/capture"
+    stub_post_request url: url, status: 201, response_body: payment_response
+  end
+
+  def stub_payment_create
+    stub_post_request url: "https://api.test.lpt.local/v2/payments",
+                      status: 200,
+                      response_body: payment_response
+  end
+
+  def stub_payment_refund(id: Lpt::PREFIX_PAYMENT)
+    url = "https://api.test.lpt.local/v2/payments/#{id}/refund"
+    stub_post_request url: url, status: 201, response_body: payment_response
+  end
+
+  def stub_payment_retrieve(id: Lpt::PREFIX_PAYMENT)
+    stub_get_request url: "https://api.test.lpt.local/v2/payments/#{id}",
+                     response_body: payment_response(id: id),
+                     status: 200
+  end
+
+  def stub_payment_reverse(id: Lpt::PREFIX_PAYMENT)
+    url = "https://api.test.lpt.local/v2/payments/#{id}/reverse"
+    stub_post_request url: url, status: 201, response_body: payment_response
+  end
+
+  def stub_payment_void(id: Lpt::PREFIX_PAYMENT)
+    url = "https://api.test.lpt.local/v2/payments/#{id}/void"
+    stub_post_request url: url, status: 201, response_body: payment_response
+  end
+
+  def payment_response(id: Lpt::PREFIX_PAYMENT)
+    <<~JSON
+      {
+        "id": "#{id}",
+        "reference_id": "r7LN2Lz9t6dcCUHlYSnFs2Y-_eHGq"
+      }
+    JSON
+  end
+end

--- a/spec/support/helpers/profile_helper.rb
+++ b/spec/support/helpers/profile_helper.rb
@@ -1,20 +1,19 @@
 # frozen_string_literal: true
 
 module ProfileHelper
-  def stub_profile_retrieve(id: "LID")
+  def stub_profile_retrieve(id: Lpt::PREFIX_PROFILE)
     stub_get_request url: "https://api.test.lpt.local/v2/profiles/#{id}",
                      response_body: profile_response(id: id),
                      status: 200
   end
 
-  def stub_profile_create(request:)
+  def stub_profile_create
     stub_post_request url: "https://api.test.lpt.local/v2/profiles",
-                      request_body: request.to_json,
                       status: 200,
                       response_body: profile_response
   end
 
-  def profile_response(id: "LIDXXXXXXXXXXX")
+  def profile_response(id: Lpt::PREFIX_PROFILE)
     <<~JSON
       {
         "id": "#{id}",


### PR DESCRIPTION
This pull-requests finalizes the first pass implementation of the core
resources required for working with the LPT API.

Some of the important changes include:
* Ensuring that the `entity` is included in all API requests. By default
  it will pull directly from `Lpt.entity`, however this can be overriden
  by using the `entity` attribute on the base `Lpt::Requests::ApiRequest`
  class
* Introduces associating an instrument token to a profile through the
  `Lpt::Resources::Profile` class. This should match the expectations
  set in the LPT guides
* Similarly implementing the various operations that are related to
  payments (capture, refund, reverse, void)
* Standardizing the code style to follow the defined Rubocop rules
* Adding unit level test coverage for all of the resources and
  operations implemented

We're currently lacking in integration tests, but we should be able to
improve that in the near future. One blocker is understading if we can
create an instrument token via the backend, rather than only through
the VGS front end client.

Co-authored-by: Chris Woodford <chris.woodford@gmail.com>
Co-authored-by: Michael Menefee <mcm@lacorepayments.com>