### PR TITLE
Implement Instrument Tokenization

### DIFF
--- a/lib/lpt/requests/instrument_token_request.rb
+++ b/lib/lpt/requests/instrument_token_request.rb
@@ -4,7 +4,7 @@ module Lpt
   module Requests
     class InstrumentTokenRequest < ApiRequest
       attr_accessor :profile, :instrument_id, :reference_id, :name, :contact,
-                    :address, :expiration, :token
+                    :address, :expiration, :account, :security_code, :token
     end
   end
 end

--- a/lib/lpt/resources/instrument.rb
+++ b/lib/lpt/resources/instrument.rb
@@ -16,6 +16,12 @@ module Lpt
         Lpt::PREFIX_INSTRUMENT
       end
 
+      def self.tokenize(instrument_token_request)
+        resource = new
+        path = "#{resource.resources_path}/token"
+        Lpt::Resources::Instrument.create(instrument_token_request, path: path)
+      end
+
       protected
 
       def assign_object_name

--- a/spec/features/set_up_a_profile_spec.rb
+++ b/spec/features/set_up_a_profile_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "set up a profile" do
+  before { configure_client }
+
+  it "can assign an instrument" do
+    stub_profile_create
+    stub_instrument_tokenize
+    stub_instrument_create
+
+    profile = create_profile(name: "Test Profile", email: "test@example.com",
+                             phone: "+14155555555")
+    token = create_token(card_number: "4242424242424242", security_code: "444",
+                         expiration: "04/20444")
+    instrument_token_request = Lpt::Requests::InstrumentTokenRequest.new
+    instrument_token_request.token = token.id
+    instrument = profile.associate_instrument(instrument_token_request)
+
+    expect(instrument.id).to start_with(Lpt::PREFIX_INSTRUMENT)
+  end
+
+  def create_profile(name:, email:, phone:)
+    profile_request = Lpt::Requests::ProfileRequest.new(
+      name: name, contact: { phone: phone, email: email }
+    )
+    Lpt::Resources::Profile.create(profile_request)
+  end
+
+  def create_token(card_number:, security_code:, expiration:)
+    instrument_token_request = Lpt::Requests::InstrumentTokenRequest.new(
+      account: card_number, security_code: security_code, expiration: expiration
+    )
+    Lpt::Resources::Instrument.tokenize(instrument_token_request)
+  end
+end

--- a/spec/lpt/resources/instrument_spec.rb
+++ b/spec/lpt/resources/instrument_spec.rb
@@ -11,6 +11,23 @@ RSpec.describe Lpt::Resources::Instrument do
     end
   end
 
+  describe ".tokenize" do
+    before { configure_client }
+
+    it "returns the tokenized instrument" do
+      token_id = "#{Lpt::PREFIX_TOKEN}XXXXXXXX"
+      stub_instrument_tokenize token_id: token_id
+      request = Lpt::Requests::InstrumentTokenRequest.new(
+        account: "4242424242424242", security_code: "444",
+        expiration: "04/2044"
+      )
+
+      result = Lpt::Resources::Instrument.tokenize(request)
+
+      expect(result.id).to eq(token_id)
+    end
+  end
+
   describe ".retrieve" do
     before { configure_client }
 

--- a/spec/lpt/resources/profile_spec.rb
+++ b/spec/lpt/resources/profile_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Lpt::Resources::Profile do
     end
   end
 
-  describe "#create_instrument" do
+  describe "#associate_instrument" do
     before { configure_client }
 
     it "returns a truthy value" do

--- a/spec/support/helpers/instrument_helper.rb
+++ b/spec/support/helpers/instrument_helper.rb
@@ -13,6 +13,12 @@ module InstrumentHelper
                       response_body: instrument_response
   end
 
+  def stub_instrument_tokenize(token_id: Lpt::PREFIX_TOKEN)
+    stub_post_request url: "https://api.test.lpt.local/v2/instruments/token",
+                      status: 201,
+                      response_body: instrument_response(id: token_id)
+  end
+
   def instrument_response(id: Lpt::PREFIX_INSTRUMENT)
     <<~JSON
       {


### PR DESCRIPTION
This adds the ability to create a tokenized instrument, similar to what
the front-end code does when receiving the credit card information from
the customer.

In general, this isn't something that we necessarily want to use
outside of testing as we don't want customer credit card info hitting
our servers. That said, we do need this to be able to simulate the full
flow of profile creation -> tokenization -> and associating the
token/instrument to the profile. That is the first flow required in
order to start charging cards.