### PR TITLE
Implement Creating Payments

### DIFF
--- a/lib/lpt/requests/payment_request.rb
+++ b/lib/lpt/requests/payment_request.rb
@@ -5,7 +5,18 @@ module Lpt
     class PaymentRequest < ApiRequest
       attr_accessor :merchant, :merchant_account, :instrument, :invoice, :order,
                     :payment_id, :reference_id, :amount, :currency, :session,
-                    :initiation, :url, :recurring
+                    :initiation, :url, :recurring, :workflow
+
+      def initialize(*)
+        super
+        assign_merchant
+      end
+
+      protected
+
+      def assign_merchant
+        self.merchant ||= Lpt.merchant
+      end
     end
   end
 end

--- a/lib/lpt/resources/instrument.rb
+++ b/lib/lpt/resources/instrument.rb
@@ -16,10 +16,35 @@ module Lpt
         Lpt::PREFIX_INSTRUMENT
       end
 
+      def auth(payment_request)
+        create_payment(payment_request,
+                       workflow: Lpt::Resources::Payment::WORKFLOW_AUTH_CAPTURE)
+      end
+
+      def charge(payment_request)
+        create_payment(payment_request,
+                       workflow: Lpt::Resources::Payment::WORKFLOW_SALE)
+      end
+
       protected
 
       def assign_object_name
         @object_name = "instrument"
+      end
+
+      def assert_valid_id_exists!
+        return if id.present?
+
+        raise ArgumentError, "An instrument ID is required"
+      end
+
+      def create_payment(payment_request, workflow:)
+        assert_valid_id_exists!
+        payment_request.workflow = workflow
+        payment_request.instrument = id
+        Lpt::Resources::Payment.create(payment_request)
+      rescue ArgumentError
+        false
       end
     end
   end

--- a/lib/lpt/resources/payment.rb
+++ b/lib/lpt/resources/payment.rb
@@ -7,6 +7,9 @@ module Lpt
       extend Lpt::ApiOperations::Create
       extend Lpt::ApiOperations::Update
 
+      WORKFLOW_SALE = "SALE"
+      WORKFLOW_AUTH_CAPTURE = "AUTH_CAPTURE"
+
       attr_accessor :payment_id, :reference_id, :instrument,
                     :instrument_identifier, :initiation, :merchant,
                     :merchant_account, :workflow, :amount, :currency, :order,

--- a/spec/lpt/requests/api_request_spec.rb
+++ b/spec/lpt/requests/api_request_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Lpt::Requests::ApiRequest do
+  describe "#initialize" do
+    it "assigns the entity" do
+      Lpt.entity = "LEN123123123"
+      result = Lpt::Requests::ApiRequest.new
+
+      expect(result.entity).to eq("LEN123123123")
+    end
+  end
+end

--- a/spec/lpt/requests/payment_request_spec.rb
+++ b/spec/lpt/requests/payment_request_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Lpt::Requests::PaymentRequest do
+  describe "#initialize" do
+    it "assigns the merchant" do
+      Lpt.merchant = "LMR123123123"
+      result = Lpt::Requests::PaymentRequest.new
+
+      expect(result.merchant).to eq("LMR123123123")
+    end
+  end
+end

--- a/spec/lpt/resources/instrument_spec.rb
+++ b/spec/lpt/resources/instrument_spec.rb
@@ -11,6 +11,132 @@ RSpec.describe Lpt::Resources::Instrument do
     end
   end
 
+  describe "#auth" do
+    before { configure_client }
+
+    it "returns a truthy value" do
+      instrument_id = "LPI123123123123"
+      instrument = Lpt::Resources::Instrument.new(id: instrument_id)
+      request = Lpt::Requests::PaymentRequest.new
+      stub_payment_create
+
+      result = instrument.auth(request)
+
+      expect(result).to be_truthy
+    end
+
+    it "assigns the auth capture workflow to the request" do
+      instrument_id = "LPI123123123123"
+      instrument = Lpt::Resources::Instrument.new(id: instrument_id)
+      request = Lpt::Requests::PaymentRequest.new
+      allow(request).to receive(:workflow=).and_call_original
+      stub_payment_create
+
+      instrument.auth(request)
+
+      expect(request).to have_received(:workflow=).once.with(
+        Lpt::Resources::Payment::WORKFLOW_AUTH_CAPTURE
+      )
+    end
+
+    it "assigns the instrument ID to the request" do
+      instrument_id = "LPI123123123123"
+      instrument = Lpt::Resources::Instrument.new(id: instrument_id)
+      request = Lpt::Requests::PaymentRequest.new
+      allow(request).to receive(:instrument=).and_call_original
+      stub_payment_create
+
+      instrument.auth(request)
+
+      expect(request).to have_received(:instrument=).once.with(instrument_id)
+    end
+
+    it "sends a create payment request" do
+      instrument_id = "LPI123123123123"
+      instrument = Lpt::Resources::Instrument.new(id: instrument_id)
+      request = Lpt::Requests::PaymentRequest.new
+      stub_payment_create
+
+      result = instrument.auth(request)
+
+      expect(result.id).to be_present
+    end
+
+    context "when the instrument does not have an ID" do
+      it "returns a falsy value" do
+        instrument = Lpt::Resources::Instrument.new(id: nil)
+        request = Lpt::Requests::PaymentRequest.new
+
+        result = instrument.auth(request)
+
+        expect(result).to be_falsy
+      end
+    end
+  end
+
+  describe "#charge" do
+    before { configure_client }
+
+    it "returns a truthy value" do
+      instrument_id = "LPI123123123123"
+      instrument = Lpt::Resources::Instrument.new(id: instrument_id)
+      request = Lpt::Requests::PaymentRequest.new
+      stub_payment_create
+
+      result = instrument.charge(request)
+
+      expect(result).to be_truthy
+    end
+
+    it "assigns the sale workflow to the request" do
+      instrument_id = "LPI123123123123"
+      instrument = Lpt::Resources::Instrument.new(id: instrument_id)
+      request = Lpt::Requests::PaymentRequest.new
+      allow(request).to receive(:workflow=).and_call_original
+      stub_payment_create
+
+      instrument.charge(request)
+
+      expect(request).to have_received(:workflow=).once.with(
+        Lpt::Resources::Payment::WORKFLOW_SALE
+      )
+    end
+
+    it "assigns the instrument ID to the request" do
+      instrument_id = "LPI123123123123"
+      instrument = Lpt::Resources::Instrument.new(id: instrument_id)
+      request = Lpt::Requests::PaymentRequest.new
+      allow(request).to receive(:instrument=).and_call_original
+      stub_payment_create
+
+      instrument.charge(request)
+
+      expect(request).to have_received(:instrument=).once.with(instrument_id)
+    end
+
+    it "sends a create payment request" do
+      instrument_id = "LPI123123123123"
+      instrument = Lpt::Resources::Instrument.new(id: instrument_id)
+      request = Lpt::Requests::PaymentRequest.new
+      stub_payment_create
+
+      result = instrument.charge(request)
+
+      expect(result.id).to be_present
+    end
+
+    context "when the instrument does not have an ID" do
+      it "returns a falsy value" do
+        instrument = Lpt::Resources::Instrument.new(id: nil)
+        request = Lpt::Requests::PaymentRequest.new
+
+        result = instrument.charge(request)
+
+        expect(result).to be_falsy
+      end
+    end
+  end
+
   describe ".retrieve" do
     before { configure_client }
 


### PR DESCRIPTION
This library currently supports two different workflow options for 
handling payments.

1. AUTH_CAPTURE -- This is a two-step workflow that first requires an
auth to be made against the Instrument, followed by a separate capture
made against the Payment
2. SALE -- This is a one-step workflow that essentially does the auth
and capture in a single API call. This requires a charge to be made
against the Instrument

I set up the PaymentRequest so that by default it will pull in the
configured Merchant. This value can be overriden by setting a
Merchant directly on the request.