### PR TITLE
Refactor Payments to Match API Semantics

### DIFF
--- a/lib/lpt/resources/instrument.rb
+++ b/lib/lpt/resources/instrument.rb
@@ -17,13 +17,19 @@ module Lpt
       end
 
       def auth(payment_request)
-        create_payment(payment_request,
-                       workflow: Lpt::Resources::Payment::WORKFLOW_AUTH_CAPTURE)
+        assert_valid_id_exists!
+        payment_request.instrument = id
+        Lpt::Resources::Payment.auth(payment_request)
+      rescue ArgumentError
+        false
       end
 
       def charge(payment_request)
-        create_payment(payment_request,
-                       workflow: Lpt::Resources::Payment::WORKFLOW_SALE)
+        assert_valid_id_exists!
+        payment_request.instrument = id
+        Lpt::Resources::Payment.sale(payment_request)
+      rescue ArgumentError
+        false
       end
 
       def self.tokenize(instrument_token_request)
@@ -42,15 +48,6 @@ module Lpt
         return if id.present?
 
         raise ArgumentError, "An instrument ID is required"
-      end
-
-      def create_payment(payment_request, workflow:)
-        assert_valid_id_exists!
-        payment_request.workflow = workflow
-        payment_request.instrument = id
-        Lpt::Resources::Payment.create(payment_request)
-      rescue ArgumentError
-        false
       end
     end
   end

--- a/lib/lpt/resources/payment.rb
+++ b/lib/lpt/resources/payment.rb
@@ -40,6 +40,16 @@ module Lpt
         Lpt::Resources::Payment.create(request, path: path)
       end
 
+      def self.auth(request)
+        request.workflow = WORKFLOW_AUTH_CAPTURE
+        Lpt::Resources::Payment.create(request)
+      end
+
+      def self.sale(request)
+        request.workflow = WORKFLOW_SALE
+        Lpt::Resources::Payment.create(request)
+      end
+
       protected
 
       def assign_object_name

--- a/spec/lpt/resources/instrument_spec.rb
+++ b/spec/lpt/resources/instrument_spec.rb
@@ -25,20 +25,6 @@ RSpec.describe Lpt::Resources::Instrument do
       expect(result).to be_truthy
     end
 
-    it "assigns the auth capture workflow to the request" do
-      instrument_id = "LPI123123123123"
-      instrument = Lpt::Resources::Instrument.new(id: instrument_id)
-      request = Lpt::Requests::PaymentRequest.new
-      allow(request).to receive(:workflow=).and_call_original
-      stub_payment_create
-
-      instrument.auth(request)
-
-      expect(request).to have_received(:workflow=).once.with(
-        Lpt::Resources::Payment::WORKFLOW_AUTH_CAPTURE
-      )
-    end
-
     it "assigns the instrument ID to the request" do
       instrument_id = "LPI123123123123"
       instrument = Lpt::Resources::Instrument.new(id: instrument_id)
@@ -51,15 +37,16 @@ RSpec.describe Lpt::Resources::Instrument do
       expect(request).to have_received(:instrument=).once.with(instrument_id)
     end
 
-    it "sends a create payment request" do
+    it "sends a payment auth request" do
       instrument_id = "LPI123123123123"
       instrument = Lpt::Resources::Instrument.new(id: instrument_id)
       request = Lpt::Requests::PaymentRequest.new
       stub_payment_create
+      allow(Lpt::Resources::Payment).to receive(:auth)
 
-      result = instrument.auth(request)
+      instrument.auth(request)
 
-      expect(result.id).to be_present
+      expect(Lpt::Resources::Payment).to have_received(:auth).once.with(request)
     end
 
     context "when the instrument does not have an ID" do
@@ -88,20 +75,6 @@ RSpec.describe Lpt::Resources::Instrument do
       expect(result).to be_truthy
     end
 
-    it "assigns the sale workflow to the request" do
-      instrument_id = "LPI123123123123"
-      instrument = Lpt::Resources::Instrument.new(id: instrument_id)
-      request = Lpt::Requests::PaymentRequest.new
-      allow(request).to receive(:workflow=).and_call_original
-      stub_payment_create
-
-      instrument.charge(request)
-
-      expect(request).to have_received(:workflow=).once.with(
-        Lpt::Resources::Payment::WORKFLOW_SALE
-      )
-    end
-
     it "assigns the instrument ID to the request" do
       instrument_id = "LPI123123123123"
       instrument = Lpt::Resources::Instrument.new(id: instrument_id)
@@ -114,15 +87,16 @@ RSpec.describe Lpt::Resources::Instrument do
       expect(request).to have_received(:instrument=).once.with(instrument_id)
     end
 
-    it "sends a create payment request" do
+    it "sends a sale payment request" do
       instrument_id = "LPI123123123123"
       instrument = Lpt::Resources::Instrument.new(id: instrument_id)
       request = Lpt::Requests::PaymentRequest.new
       stub_payment_create
+      allow(Lpt::Resources::Payment).to receive(:sale)
 
-      result = instrument.charge(request)
+      instrument.charge(request)
 
-      expect(result.id).to be_present
+      expect(Lpt::Resources::Payment).to have_received(:sale).once.with(request)
     end
 
     context "when the instrument does not have an ID" do

--- a/spec/lpt/resources/payment_spec.rb
+++ b/spec/lpt/resources/payment_spec.rb
@@ -115,6 +115,56 @@ RSpec.describe Lpt::Resources::Payment do
     end
   end
 
+  describe ".auth" do
+    before { configure_client }
+
+    it "assigns the auth capture workflow to the request" do
+      request = Lpt::Requests::PaymentRequest.new
+      allow(request).to receive(:workflow=).and_call_original
+      stub_payment_create
+
+      Lpt::Resources::Payment.auth(request)
+
+      expect(request).to have_received(:workflow=).once.with(
+        Lpt::Resources::Payment::WORKFLOW_AUTH_CAPTURE
+      )
+    end
+
+    it "returns a payment" do
+      request = Lpt::Requests::PaymentRequest.new(instrument: "LPIXXXXXXXX")
+      stub_payment_create
+
+      result = Lpt::Resources::Payment.auth(request)
+
+      expect(result.id).to start_with(Lpt::PREFIX_PAYMENT)
+    end
+  end
+
+  describe ".sale" do
+    before { configure_client }
+
+    it "assigns the sale workflow to the request" do
+      request = Lpt::Requests::PaymentRequest.new
+      allow(request).to receive(:workflow=).and_call_original
+      stub_payment_create
+
+      Lpt::Resources::Payment.sale(request)
+
+      expect(request).to have_received(:workflow=).once.with(
+        Lpt::Resources::Payment::WORKFLOW_SALE
+      )
+    end
+
+    it "returns a payment" do
+      request = Lpt::Requests::PaymentRequest.new(instrument: "LPIXXXXXXX")
+      stub_payment_create
+
+      result = Lpt::Resources::Payment.sale(request)
+
+      expect(result.id).to start_with(Lpt::PREFIX_PAYMENT)
+    end
+  end
+
   describe ".retrieve" do
     before { configure_client }
 


### PR DESCRIPTION
At its core, we want this library to follow the expected semantics of
the API, so that users of the library can see the direct line from the
API docs to the code.

As a library, we can also layer some semantic sugar on top of the API
to make the development process more smooth and easy to work with,
hiding cruft and simplifying usage as objects are available.

This PR moves the auth and sale workflows onto the Payment resources to
better match the expectations of the API and then updates the instance
methods on the Instrument class to use the Payment API as intended.

This gives two different ways to create payments, depending on what
information and context you have in your code

Example 1 -- class level methods on the Payment resource
```
instrument_id = "LPIXXXXXXXXXX"
payment_request = Lpt::Requests::PaymentRequest.new(instrument: instrument_id, amount: 1000)
Lpt::Resources::Payment.auth(payment_request)
```

Example 2 -- instance level methods on the Instrument resource
```
instrument_id = "LPIXXXXXXXXXX"
instrument = Lpt::Resources::Instrument.retrieve(instrument_id)
payment_request = Lpt::Requests::PaymentRequest.new(amount: 1000)
instrument.auth(payment_request)
```