### PR TITLE
Add Instance Methods for Expiration

### DIFF
--- a/lib/lpt/resources/instrument.rb
+++ b/lib/lpt/resources/instrument.rb
@@ -16,6 +16,14 @@ module Lpt
         Lpt::PREFIX_INSTRUMENT
       end
 
+      def expiration_month
+        expiration.with_indifferent_access["month"]
+      end
+
+      def expiration_year
+        expiration.with_indifferent_access["year"]
+      end
+
       def auth(payment_request)
         create_payment(payment_request,
                        workflow: Lpt::Resources::Payment::WORKFLOW_AUTH_CAPTURE)

--- a/spec/lpt/resources/instrument_spec.rb
+++ b/spec/lpt/resources/instrument_spec.rb
@@ -11,6 +11,30 @@ RSpec.describe Lpt::Resources::Instrument do
     end
   end
 
+  describe "#expiration_month" do
+    it "returns the month from the expiration hash" do
+      instrument = Lpt::Resources::Instrument.new(
+        expiration: { month: "04", year: "2044" }
+      )
+
+      result = instrument.expiration_month
+
+      expect(result).to eq("04")
+    end
+  end
+
+  describe "#expiration_year" do
+    it "returns the year from the expiration hash" do
+      instrument = Lpt::Resources::Instrument.new(
+        expiration: { month: "04", year: "2044" }
+      )
+
+      result = instrument.expiration_year
+
+      expect(result).to eq("2044")
+    end
+  end
+
   describe "#auth" do
     before { configure_client }
 


### PR DESCRIPTION
In most cases we are accessing the expiration month and year as scalars
rather than as an object. The goal here is just to have a couple small
helper methods to make it easier to get the data directly