### PR TITLE
Improve Working with Payment Requests

### DIFF
--- a/lib/lpt/requests/payment_request.rb
+++ b/lib/lpt/requests/payment_request.rb
@@ -3,6 +3,12 @@
 module Lpt
   module Requests
     class PaymentRequest < ApiRequest
+      INITIATION_CUSTOMER = "CUSTOMER"
+      INITIATION_MERCHANT = "MERCHANT"
+
+      WORKFLOW_SALE = "SALE"
+      WORKFLOW_AUTH_CAPTURE = "AUTH_CAPTURE"
+
       attr_accessor :merchant, :merchant_account, :instrument, :invoice, :order,
                     :payment_id, :reference_id, :amount, :currency, :session,
                     :initiation, :url, :recurring, :workflow
@@ -10,6 +16,21 @@ module Lpt
       def initialize(*)
         super
         assign_merchant
+      end
+
+      def as_auth_capture
+        self.workflow = WORKFLOW_AUTH_CAPTURE
+        self
+      end
+
+      def as_sale
+        self.workflow = WORKFLOW_SALE
+        self
+      end
+
+      def as_recurring_payment
+        self.initiation = INITIATION_MERCHANT
+        self
       end
 
       protected

--- a/lib/lpt/resources/payment.rb
+++ b/lib/lpt/resources/payment.rb
@@ -7,9 +7,6 @@ module Lpt
       extend Lpt::ApiOperations::Create
       extend Lpt::ApiOperations::Update
 
-      WORKFLOW_SALE = "SALE"
-      WORKFLOW_AUTH_CAPTURE = "AUTH_CAPTURE"
-
       attr_accessor :payment_id, :reference_id, :instrument,
                     :instrument_identifier, :initiation, :merchant,
                     :merchant_account, :workflow, :amount, :currency, :order,
@@ -40,14 +37,14 @@ module Lpt
         Lpt::Resources::Payment.create(request, path: path)
       end
 
-      def self.auth(request)
-        request.workflow = WORKFLOW_AUTH_CAPTURE
-        Lpt::Resources::Payment.create(request)
+      def self.auth(payment_request)
+        payment_request.as_auth_capture
+        Lpt::Resources::Payment.create(payment_request)
       end
 
-      def self.sale(request)
-        request.workflow = WORKFLOW_SALE
-        Lpt::Resources::Payment.create(request)
+      def self.sale(payment_request)
+        payment_request.as_sale
+        Lpt::Resources::Payment.create(payment_request)
       end
 
       protected

--- a/spec/lpt/requests/payment_request_spec.rb
+++ b/spec/lpt/requests/payment_request_spec.rb
@@ -11,4 +11,61 @@ RSpec.describe Lpt::Requests::PaymentRequest do
       expect(result.merchant).to eq("LMR123123123")
     end
   end
+
+  describe "#as_auth_capture" do
+    it "sets the workflow to auth/capture" do
+      auth_capture = Lpt::Requests::PaymentRequest::WORKFLOW_AUTH_CAPTURE
+      request = Lpt::Requests::PaymentRequest.new
+
+      request.as_auth_capture
+
+      expect(request.workflow).to eq(auth_capture)
+    end
+
+    it "supports method chaining" do
+      request = Lpt::Requests::PaymentRequest.new
+
+      result = request.as_auth_capture
+
+      expect(result).to eq(request)
+    end
+  end
+
+  describe "#as_sale" do
+    it "sets the workflow to sale" do
+      sale = Lpt::Requests::PaymentRequest::WORKFLOW_SALE
+      request = Lpt::Requests::PaymentRequest.new
+
+      request.as_sale
+
+      expect(request.workflow).to eq(sale)
+    end
+
+    it "supports method chaining" do
+      request = Lpt::Requests::PaymentRequest.new
+
+      result = request.as_sale
+
+      expect(result).to eq(request)
+    end
+  end
+
+  describe "#as_recurring_payment" do
+    it "sets initiation by the merchant" do
+      initiated_by_merchant = Lpt::Requests::PaymentRequest::INITIATION_MERCHANT
+      request = Lpt::Requests::PaymentRequest.new
+
+      request.as_recurring_payment
+
+      expect(request.initiation).to eq(initiated_by_merchant)
+    end
+
+    it "supports method chaining" do
+      request = Lpt::Requests::PaymentRequest.new
+
+      result = request.as_recurring_payment
+
+      expect(result).to eq(request)
+    end
+  end
 end

--- a/spec/lpt/resources/payment_spec.rb
+++ b/spec/lpt/resources/payment_spec.rb
@@ -120,14 +120,12 @@ RSpec.describe Lpt::Resources::Payment do
 
     it "assigns the auth capture workflow to the request" do
       request = Lpt::Requests::PaymentRequest.new
-      allow(request).to receive(:workflow=).and_call_original
+      allow(request).to receive(:as_auth_capture).and_call_original
       stub_payment_create
 
       Lpt::Resources::Payment.auth(request)
 
-      expect(request).to have_received(:workflow=).once.with(
-        Lpt::Resources::Payment::WORKFLOW_AUTH_CAPTURE
-      )
+      expect(request).to have_received(:as_auth_capture).once
     end
 
     it "returns a payment" do
@@ -145,14 +143,12 @@ RSpec.describe Lpt::Resources::Payment do
 
     it "assigns the sale workflow to the request" do
       request = Lpt::Requests::PaymentRequest.new
-      allow(request).to receive(:workflow=).and_call_original
+      allow(request).to receive(:as_sale).and_call_original
       stub_payment_create
 
       Lpt::Resources::Payment.sale(request)
 
-      expect(request).to have_received(:workflow=).once.with(
-        Lpt::Resources::Payment::WORKFLOW_SALE
-      )
+      expect(request).to have_received(:as_sale).once
     end
 
     it "returns a payment" do


### PR DESCRIPTION
This commit introduces some a few methods on the Payment Request class
to cover some of the specific use cases that payments have. The end
result is a more fluent API.

1. Two of the methods are a refactoring of the previous workflow
   implementation. Rather than leak the constants out into the Payment
   resource class, I opted to encapulate their usage behind methods that
   clearly describe their intent.
2. Adding a method to mark a request as a being initiated by the
   merchant rather than by the customer (customer initiation is the
   default). The core use case here is recurring payments.

The expected usage will could look something like this:

```
Lpt::Requests::PaymentRequest.
  new.
  as_recurring_payment.
  as_sale
```