### PR TITLE
Improve Response Handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source "https://rubygems.org"
 gemspec
 
 group :test, :development do
+  gem "pry"
   gem "rake", "~> 13.0"
   gem "rspec", "~> 3.0"
   gem "rubocop", "~> 1.21"

--- a/lib/lpt.rb
+++ b/lib/lpt.rb
@@ -34,6 +34,7 @@ module Lpt
   LEVEL_DEBUG = Logger::DEBUG
   LEVEL_ERROR = Logger::ERROR
   LEVEL_INFO = Logger::INFO
+  LEVEL_TEST = -1
 
   PREFIX_ENTITY = "LEN"
   PREFIX_MERCHANT = "LMR"

--- a/lib/lpt.rb
+++ b/lib/lpt.rb
@@ -67,10 +67,12 @@ module Lpt
     end
 
     def base_addresses(environment: nil)
-      if environment == Lpt::Environment::PRODUCTION
+      case environment
+      when Lpt::Environment::PRODUCTION
         { api_base: "api-s2", cx_base: "cx", cx_api_base: "api.cx" }
-      elsif environment == Lpt::Environment::STAGING
-        { api_base: "staging-api-s2", cx_base: "cx.stg", cx_api_base: "api.cx.stg" }
+      when Lpt::Environment::STAGING
+        { api_base: "staging-api-s2", cx_base: "cx.stg",
+          cx_api_base: "api.cx.stg" }
       else
         { api_base: "api", cx_base: "cx", cx_api_base: "api.cx" }
       end

--- a/lib/lpt/lpt_client.rb
+++ b/lib/lpt/lpt_client.rb
@@ -39,7 +39,7 @@ module Lpt
         return if Lpt.log_level.negative?
 
         config.response :logger, nil, **logging_options do |fmt|
-          fmt.filter(/^(Buthorization: ).*$/i, '\1[REDACTED]')
+          fmt.filter(/^(Authorization: ).*$/i, '\1[REDACTED]')
         end
       end
 

--- a/lib/lpt/resources/api_resource.rb
+++ b/lib/lpt/resources/api_resource.rb
@@ -71,6 +71,8 @@ module Lpt
       end
 
       def hydrate_attributes(attributes)
+        return unless attributes.respond_to? :each_pair
+
         attributes.each_pair do |k, v|
           setter = :"#{k}="
           public_send(setter, v)

--- a/spec/lpt/lpt_client_spec.rb
+++ b/spec/lpt/lpt_client_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Lpt::LptClient do
+  describe "#factory" do
+    it "configures logging" do
+      Lpt.log_level = Lpt::LEVEL_DEBUG
+      env = Lpt::Environment.factory(environment: Lpt::Environment::STAGING)
+
+      result = Lpt::LptClient.factory(environment: env).builder.handlers
+
+      expect(result).to include(Faraday::Response::Logger)
+    end
+
+    context "when the log level is set to test" do
+      it "does not configure logging" do
+        Lpt.log_level = Lpt::LEVEL_TEST
+        env = Lpt::Environment.factory(environment: Lpt::Environment::TEST)
+
+        result = Lpt::LptClient.factory(environment: env).builder.handlers
+
+        expect(result).not_to include(Faraday::Response::Logger)
+      end
+    end
+  end
+end

--- a/spec/lpt/resources/api_resource_spec.rb
+++ b/spec/lpt/resources/api_resource_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe Lpt::Resources::ApiResource do
         }.not_to raise_error
       end
     end
+
+    context "when key/value pairs are not passed in" do
+      it "does not raise an error" do
+        expect {
+          Lpt::Resources::ApiResource.new("OK")
+        }.not_to raise_error
+      end
+    end
   end
 
   describe "#base_path" do

--- a/spec/lpt_spec.rb
+++ b/spec/lpt_spec.rb
@@ -8,6 +8,18 @@ RSpec.describe Lpt do
   end
 
   describe "#base_addresses" do
+    context "when the environment is production" do
+      it "returns the prodution base addresses" do
+        prod_env = Lpt::Environment::PRODUCTION
+        prod_base = { api_base: "api-s2", cx_base: "cx",
+                      cx_api_base: "api.cx" }
+
+        result = Lpt.base_addresses(environment: prod_env)
+
+        expect(result).to eq(prod_base)
+      end
+    end
+
     context "when the environment is staging" do
       it "returns the staging base addresses" do
         staging_env = Lpt::Environment::STAGING
@@ -22,11 +34,11 @@ RSpec.describe Lpt do
 
     context "when the environment is not staging" do
       it "returns the non-staging base addresses" do
-        prod_env = Lpt::Environment::PRODUCTION
+        test_env = Lpt::Environment::TEST
         non_staging_base = { api_base: "api", cx_base: "cx",
                              cx_api_base: "api.cx" }
 
-        result = Lpt.base_addresses(environment: prod_env)
+        result = Lpt.base_addresses(environment: test_env)
 
         expect(result).to eq(non_staging_base)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
+require "pry"
 require "webmock/rspec"
 
 require "lpt"
 
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
+
+Lpt.log_level = Lpt::LEVEL_TEST
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
There's an issue currently where the API is returning a positive 
status code (200) but not returning a JSON response body, it is
simply returning the string "OK".

This string value caused the API resource code to explode as it
was assuming that it would always have a hash of key/values to
work with.

I approached handling this in two ways:
1. I added a guard clause in the ApiResource instantiation that will
   ignore anything passed in that doesn't respond to a method called
   `each_pair`. This will work with the current use case as Hash does
   respond to each_pair and it allows for future polymorphism as any
   class passed in would just need to implement that method (i.e. duck
   typing)
2. Updating the LptClient class to configure the logger based on the
   value in Lpt.log_level. Previously I had turned logging off as it
   was extremely noisy in the test suite.. though this was a disservice
   from the development perspective. This implementation will allow
   the test suite to turn logging off and allow development to control
   the level of logging that makes sense for their needs.

Additionally I added a small commit introducing Pry in the test suite
to help make inspection and debugging a bit easier.

Finally the HEAD commit in master introduced a failing test. I 
resolved the issue, added a new test, and improved the code to be a bit
more Ruby like (i.e. got rid of the dreaded `elsif`)