### PR TITLE
Add Approval Check for Payments

### DIFF
--- a/lib/lpt/resources/payment.rb
+++ b/lib/lpt/resources/payment.rb
@@ -13,6 +13,10 @@ module Lpt
                     :invoice, :session, :profile, :authorization, :presentment,
                     :reversal, :refunds, :amount_refundable, :result, :url
 
+      def approved?
+        result.with_indifferent_access["approved"] == "true"
+      end
+
       def id_prefix
         Lpt::PREFIX_PAYMENT
       end

--- a/spec/lpt/resources/payment_spec.rb
+++ b/spec/lpt/resources/payment_spec.rb
@@ -11,6 +11,24 @@ RSpec.describe Lpt::Resources::Payment do
     end
   end
 
+  describe "#approved?" do
+    context "when the result approved flag is set to true" do
+      it "is approved" do
+        payment = Lpt::Resources::Payment.new(result: { approved: "true" })
+
+        expect(payment).to be_approved
+      end
+    end
+
+    context "when the result approved flag is not set to true" do
+      it "is not approved" do
+        payment = Lpt::Resources::Payment.new(result: { approved: "false" })
+
+        expect(payment).not_to be_approved
+      end
+    end
+  end
+
   describe "#capture" do
     before { configure_client }
 


### PR DESCRIPTION
When calling the `/v2/payments` endpoint, the easiest thing to look at
in order to understand if the Payment attempt was succesful is
`result.approved`

Rather than requiring the calling code to work with `result` object
directly, we can add a basic `#approved?` predicate method on the
Payment class. This will allow the calling code to easily confirm if a
Payment was successful and act accordingly.