### PR TITLE
Extract Token Path to Class Method

### DIFF
--- a/lib/lpt.rb
+++ b/lib/lpt.rb
@@ -79,6 +79,10 @@ module Lpt
       end
     end
 
+    def token_path(entity: nil)
+      Lpt::Resources::Instrument.token_path(entity: entity)
+    end
+
     def open_timeout
       @open_timeout || 30
     end

--- a/lib/lpt/resources/instrument.rb
+++ b/lib/lpt/resources/instrument.rb
@@ -41,9 +41,13 @@ module Lpt
       end
 
       def self.tokenize(instrument_token_request)
-        resource = new
-        path = "#{resource.resources_path}/token"
+        path = token_path
         Lpt::Resources::Instrument.create(instrument_token_request, path: path)
+      end
+
+      def self.token_path(entity: nil)
+        resource = new
+        [resource.resources_path, "token", entity].compact.join("/")
       end
 
       protected

--- a/spec/lpt/resources/instrument_spec.rb
+++ b/spec/lpt/resources/instrument_spec.rb
@@ -135,6 +135,26 @@ RSpec.describe Lpt::Resources::Instrument do
     end
   end
 
+  describe ".token_path" do
+    context "when not entity is passed in" do
+      it "returns the base path" do
+        result = Lpt::Resources::Instrument.token_path
+
+        expect(result).to eq("/v2/instruments/token")
+      end
+    end
+
+    context "when an entity is passed in" do
+      it "returns the base path with the entity" do
+        entity = "LEN123"
+
+        result = Lpt::Resources::Instrument.token_path(entity: entity)
+
+        expect(result).to eq("/v2/instruments/token/LEN123")
+      end
+    end
+  end
+
   describe ".tokenize" do
     before { configure_client }
 

--- a/spec/lpt_spec.rb
+++ b/spec/lpt_spec.rb
@@ -7,6 +7,28 @@ RSpec.describe Lpt do
     expect(Lpt::VERSION).not_to be_nil
   end
 
+  describe "#token_path" do
+    it "delegates to the instrument class" do
+      allow(Lpt::Resources::Instrument).to receive(:token_path)
+
+      Lpt.token_path
+
+      expect(Lpt::Resources::Instrument).to have_received(:token_path).once
+    end
+
+    context "when the entity is included" do
+      it "delegates to the instrument class with the entity" do
+        entity = "LEN"
+        allow(Lpt::Resources::Instrument).to receive(:token_path)
+
+        Lpt.token_path(entity: entity)
+
+        expect(Lpt::Resources::Instrument).to have_received(:token_path).once.
+          with(entity: "LEN")
+      end
+    end
+  end
+
   describe "#base_addresses" do
     context "when the environment is production" do
       it "returns the prodution base addresses" do


### PR DESCRIPTION
The token path is the path used externally (in front-end
implementations) to make a request to tokenize a credit card. In
particular it is the path used by the VGS javascript library to post
credit card details.

It's best to expose this path via the gem so that client code has a
central and standard place to get the token path.