### PR TITLE
Improve Handling of Object Values in Resources

### DIFF
--- a/lib/lpt/resources/instrument.rb
+++ b/lib/lpt/resources/instrument.rb
@@ -17,10 +17,14 @@ module Lpt
       end
 
       def expiration_month
+        return false unless expiration.respond_to? :with_indifferent_access
+
         expiration.with_indifferent_access["month"]
       end
 
       def expiration_year
+        return false unless expiration.respond_to? :with_indifferent_access
+
         expiration.with_indifferent_access["year"]
       end
 

--- a/lib/lpt/resources/payment.rb
+++ b/lib/lpt/resources/payment.rb
@@ -14,6 +14,8 @@ module Lpt
                     :reversal, :refunds, :amount_refundable, :result, :url
 
       def approved?
+        return false unless result.respond_to? :with_indifferent_access
+
         result.with_indifferent_access["approved"] == "true"
       end
 

--- a/spec/lpt/resources/instrument_spec.rb
+++ b/spec/lpt/resources/instrument_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe Lpt::Resources::Instrument do
 
       expect(result).to eq("04")
     end
+
+    context "when the expiration is not set" do
+      it "does not raise an error" do
+        instrument = Lpt::Resources::Instrument.new(expiration: nil)
+
+        expect {
+          instrument.expiration_month
+        }.not_to raise_error
+      end
+    end
   end
 
   describe "#expiration_year" do
@@ -32,6 +42,16 @@ RSpec.describe Lpt::Resources::Instrument do
       result = instrument.expiration_year
 
       expect(result).to eq("2044")
+    end
+
+    context "when the expiration is not set" do
+      it "does not raise an error" do
+        instrument = Lpt::Resources::Instrument.new(expiration: nil)
+
+        expect {
+          instrument.expiration_year
+        }.not_to raise_error
+      end
     end
   end
 

--- a/spec/lpt/resources/payment_spec.rb
+++ b/spec/lpt/resources/payment_spec.rb
@@ -27,6 +27,22 @@ RSpec.describe Lpt::Resources::Payment do
         expect(payment).not_to be_approved
       end
     end
+
+    context "when the result is not set" do
+      it "does not raise an error" do
+        payment = Lpt::Resources::Payment.new(result: nil)
+
+        expect {
+          payment.approved?
+        }.not_to raise_error
+      end
+
+      it "is not approved" do
+        payment = Lpt::Resources::Payment.new(result: nil)
+
+        expect(payment).not_to be_approved
+      end
+    end
   end
 
   describe "#capture" do


### PR DESCRIPTION
There are a few helper methods that have been added to the Payment and
Instrument resource classes that reach into objects (ie Hash) under the
hood. In cases where that object has not be initialized with a value,
the helper methods explode and raise a method not found error.

To better guard against these edge cases, I've introduced a check to
ensure that the object responds to `with_indifferent_access` before
attempting to pull a value