### PR TITLE
Optionally Include Protocol with API Base URL

### DIFF
--- a/lib/lpt.rb
+++ b/lib/lpt.rb
@@ -53,6 +53,8 @@ module Lpt
                 :max_network_retry_delay, :verify_ssl_certs, :ca_bundle_path,
                 :log_level
 
+    delegate :api_base_url, to: :env
+
     def environment=(environment)
       standard_env = standardize_environment(environment)
       assert_environment_is_valid! standard_env
@@ -130,6 +132,10 @@ module Lpt
 
     def envs
       Lpt::Environment::ENVIRONMENTS.values
+    end
+
+    def env
+      @env ||= Lpt::Environment.factory(environment: environment)
     end
   end
 end

--- a/lib/lpt/environment.rb
+++ b/lib/lpt/environment.rb
@@ -47,8 +47,8 @@ module Lpt
         cx_base == other.cx_base && cx_api_base == other.cx_api_base
     end
 
-    def api_base_url
-      base_url(api_base)
+    def api_base_url(with_protocol: true)
+      base_url(api_base, with_protocol: with_protocol)
     end
 
     def cx_base_url
@@ -77,8 +77,9 @@ module Lpt
 
     protected
 
-    def base_url(host)
-      "https://#{host}.#{base_domain}/"
+    def base_url(cname, with_protocol: true)
+      protocol = "https://" if with_protocol
+      "#{protocol}#{cname}.#{base_domain}"
     end
   end
 end

--- a/spec/lpt/environment_spec.rb
+++ b/spec/lpt/environment_spec.rb
@@ -34,7 +34,18 @@ RSpec.describe Lpt::Environment do
 
       result = environment.api_base_url
 
-      expect(result).to eq("https://testing.lpt.io/")
+      expect(result).to eq("https://testing.lpt.io")
+    end
+
+    context "when not including the protocol" do
+      it "builds the full url without the protocol" do
+        environment = Lpt::Environment.new(api_base: "testing",
+                                           base_domain: "lpt.io")
+
+        result = environment.api_base_url(with_protocol: false)
+
+        expect(result).to eq("testing.lpt.io")
+      end
     end
   end
 
@@ -45,7 +56,7 @@ RSpec.describe Lpt::Environment do
 
       result = environment.cx_base_url
 
-      expect(result).to eq("https://cx.testing.lpt.io/")
+      expect(result).to eq("https://cx.testing.lpt.io")
     end
   end
 
@@ -56,7 +67,7 @@ RSpec.describe Lpt::Environment do
 
       result = environment.cx_api_base_url
 
-      expect(result).to eq("https://cx.api.testing.lpt.io/")
+      expect(result).to eq("https://cx.api.testing.lpt.io")
     end
   end
 

--- a/spec/lpt_spec.rb
+++ b/spec/lpt_spec.rb
@@ -2,9 +2,21 @@
 
 require "spec_helper"
 
-RSpec.describe Lpt do
+RSpec.describe Lpt, type: :model do
   it "has a version number" do
     expect(Lpt::VERSION).not_to be_nil
+  end
+
+  describe "#api_base_url" do
+    it "delegates to the environment" do
+      env = Lpt::Environment.factory(environment: Lpt::Environment::TEST)
+      allow(env).to receive(:api_base_url)
+      allow(Lpt::Environment).to receive(:factory).and_return(env)
+
+      Lpt.api_base_url
+
+      expect(env).to have_received(:api_base_url).once
+    end
   end
 
   describe "#base_addresses" do


### PR DESCRIPTION
The VGS javascript that is used on the front end for tokenizing credit
card info requires the base API url without the protocol. In order to
easily support this requirement, we can allow an optional param to be
passed into the `#api_base_url` method, which will return the base url
without the protocol.

To make this even easier, I added a delegator class method on the Lpt
class so that the client code can access `Lpt.api_base_url` directly.