### PR TITLE
Resolve Bug in Payment Model

### DIFF
--- a/lib/lpt/resources/payment.rb
+++ b/lib/lpt/resources/payment.rb
@@ -16,7 +16,7 @@ module Lpt
       def approved?
         return false unless result.respond_to? :with_indifferent_access
 
-        result.with_indifferent_access["approved"] == "true"
+        result.with_indifferent_access["approved"] == true
       end
 
       def id_prefix

--- a/spec/lpt/resources/payment_spec.rb
+++ b/spec/lpt/resources/payment_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Lpt::Resources::Payment do
   describe "#approved?" do
     context "when the result approved flag is set to true" do
       it "is approved" do
-        payment = Lpt::Resources::Payment.new(result: { approved: "true" })
+        payment = Lpt::Resources::Payment.new(result: { approved: true })
 
         expect(payment).to be_approved
       end
@@ -22,7 +22,7 @@ RSpec.describe Lpt::Resources::Payment do
 
     context "when the result approved flag is not set to true" do
       it "is not approved" do
-        payment = Lpt::Resources::Payment.new(result: { approved: "false" })
+        payment = Lpt::Resources::Payment.new(result: { approved: false })
 
         expect(payment).not_to be_approved
       end


### PR DESCRIPTION
When Faraday parses the JSON response from the API, it converts the
true/false string values to true/false booleans. The initial
implementation of `Payment#approved?` assumed that it needed to check
against the string version of "true". This commit updates the check to
be against a boolean `true`.