### PR TITLE
Update Gem Host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 .idea/
 .ruby-version
 .rspec_status
+pkg/

--- a/lpt-ruby.gemspec
+++ b/lpt-ruby.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
   spec.required_ruby_version = ">= 2.6.0"
 
-  spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
+  spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/lacore-payment-tech/lpt-ruby"


### PR DESCRIPTION
We have neglected to update the `allowed_push_host`, this is a
requirement for releasing the gem.