### PR TITLE
Improve Error Handling for Create/Retrieve

### DIFF
--- a/lib/lpt.rb
+++ b/lib/lpt.rb
@@ -8,6 +8,7 @@ require "logger"
 require_relative "lpt/authentication"
 require_relative "lpt/version"
 require_relative "lpt/environment"
+require_relative "lpt/errors"
 require_relative "lpt/lpt_client"
 
 require_relative "lpt/api_operations/create"
@@ -27,8 +28,6 @@ require_relative "lpt/requests/payment_request"
 require_relative "lpt/requests/profile_request"
 
 module Lpt
-  class Error < StandardError; end
-
   DEFAULT_CA_BUNDLE_PATH = "#{__dir__}/data/ca-certificates.crt"
 
   LEVEL_DEBUG = Logger::DEBUG

--- a/lib/lpt/api_operations/create.rb
+++ b/lib/lpt/api_operations/create.rb
@@ -10,6 +10,8 @@ module Lpt
         response = client.post(path, request.to_json)
         handle_response resource, response
         resource
+      rescue Faraday::Error => e
+        raise Lpt::ResourceCreationFailure, e.message
       end
 
       protected

--- a/lib/lpt/api_operations/retrieve.rb
+++ b/lib/lpt/api_operations/retrieve.rb
@@ -8,6 +8,8 @@ module Lpt
         resource = new(id: id)
         response = client.get(resource.resource_path)
         new(response.body)
+      rescue Faraday::Error => e
+        raise Lpt::ResourceRetrievalFailure, e.message
       end
     end
   end

--- a/lib/lpt/errors.rb
+++ b/lib/lpt/errors.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Lpt
+  class LptError < RuntimeError; end
+
+  class ResourceCreationFailure < LptError; end
+  class ResourceRetrievalFailure < LptError; end
+end

--- a/spec/support/helpers/client_helper.rb
+++ b/spec/support/helpers/client_helper.rb
@@ -20,10 +20,18 @@ module ClientHelper
       to_return(status: status, body: response_body, headers: headers)
   end
 
+  def stub_get_request_to_fail(url:, error: RuntimeError)
+    stub_request(:get, url).to_raise(error.new)
+  end
+
   def stub_post_request(url:, status:, response_body:)
     response_headers = { "content-type": "application/json; charset=UTF-8" }
 
     stub_request(:post, url).
       to_return(status: status, body: response_body, headers: response_headers)
+  end
+
+  def stub_post_request_to_fail(url:, error: RuntimeError)
+    stub_request(:post, url).to_raise(error.new)
   end
 end

--- a/spec/support/helpers/payment_helper.rb
+++ b/spec/support/helpers/payment_helper.rb
@@ -12,6 +12,11 @@ module PaymentHelper
                       response_body: payment_response
   end
 
+  def stub_payment_create_failure(error:)
+    stub_post_request_to_fail url: "https://api.test.lpt.local/v2/payments",
+                              error: error
+  end
+
   def stub_payment_refund(id: Lpt::PREFIX_PAYMENT)
     url = "https://api.test.lpt.local/v2/payments/#{id}/refund"
     stub_post_request url: url, status: 201, response_body: payment_response
@@ -21,6 +26,12 @@ module PaymentHelper
     stub_get_request url: "https://api.test.lpt.local/v2/payments/#{id}",
                      response_body: payment_response(id: id),
                      status: 200
+  end
+
+  def stub_payment_retrieve_failure(id:, error:)
+    stub_get_request_to_fail(
+      url: "https://api.test.lpt.local/v2/payments/#{id}", error: error
+    )
   end
 
   def stub_payment_reverse(id: Lpt::PREFIX_PAYMENT)


### PR DESCRIPTION
We have a problem where the low level Faraday errors are bubbling up
outside of the context of this gem. It's not a great experience for gem
users.

We want to control the narrative around the errors at the gem level,
consuming the raw API errors from Faraday and then re-raise LPT owned
errors, which will allow the gem users to better understand what has
happened.

I've implemented this at a high level of granularity, right now just
resource creation failure and resource retrieval failure. These inherit
from a general LPT error. It's a very minimal implementation at the
moment but it sets us up to expand and scale the error handling over
time.

Gem users can get specifics about the error via the message attribute on
the error. If this proves to be too troublesome or gem users need more
granular error classes to manage their control flow.. we can cross that
bridge when we get there.